### PR TITLE
Indicate the current CheriBSD version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ Topics include how to download and install prebuilt CheriBSD images, how to
 build your own images, how third-party packages work, and where to find
 further information and support.
 
+<!--
+NOTE: A release version is also in SUMMARY.md.
+-->
+**The document describes CheriBSD as of the 22.05 release, unless explicitly
+stated in sections referring to earlier or later releases.**
+
 *This document is a work-in-progress.  Feedback and contributions are
 welcomed.  Please see our [GitHub
 Repository](https://github.com/CTSRD-CHERI/cheribsd-getting-started) for the

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -14,3 +14,8 @@
 - [Morello known issues](issues/README.md)
 - [Getting help](support/README.md)
 - [Resources](resources/README.md)
+
+<!--
+NOTE: A release version is also in README.md.
+-->
+[Current release: 22.05]()

--- a/src/packages/README.md
+++ b/src/packages/README.md
@@ -5,10 +5,6 @@ CheriBSD on Morello ships with both hybrid and CheriABI packages
 form of code generation and Application Binary Interface (ABI).
 They have different levels of completeness, maturity, security, and support.
 
-**This document describes CheriBSD support for packages as of the 22.05
-release, which differs substantially from prior releases and software
-snapshots due to the introduction of a `pkg64c` package set.**
-
 ## Hybrid ABI packages
 
 **Hybrid ABI packages** are compiled almost identically to packages in the


### PR DESCRIPTION
We should inform a user on the main page what is a CheriBSD release the guide refers to, unless explicitly stated in sections.