### PR TITLE
Add a section on package upgrades.

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -17,6 +17,7 @@
 - [Third-party packages](packages/README.md)
   - [Limitations of packages](packages/limitations.md)
   - [Upgrading packages](packages/upgrading.md)
+  - [Useful commands](packages/commands.md)
 - [CheriABI "Hello World"](helloworld/README.md)
 - [Getting help](support/README.md)
 - [Resources](resources/README.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -16,6 +16,7 @@
   - [Morello known issues](morello-issues/README.md)
 - [Third-party packages](packages/README.md)
   - [Limitations of packages](packages/limitations.md)
+  - [Missing packages](packages/missing.md)
   - [Upgrading packages](packages/upgrading.md)
   - [Useful commands](packages/commands.md)
 - [CheriABI "Hello World"](helloworld/README.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -16,6 +16,7 @@
   - [Morello known issues](morello-issues/README.md)
 - [Third-party packages](packages/README.md)
   - [Limitations of packages](packages/limitations.md)
+  - [Upgrading packages](packages/upgrading.md)
 - [CheriABI "Hello World"](helloworld/README.md)
 - [Getting help](support/README.md)
 - [Resources](resources/README.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -15,6 +15,7 @@
   - [Installing on a Morello board](morello-install/README.md)
   - [Morello known issues](morello-issues/README.md)
 - [Third-party packages](packages/README.md)
+  - [Limitations of packages](packages/limitations.md)
 - [CheriABI "Hello World"](helloworld/README.md)
 - [Getting help](support/README.md)
 - [Resources](resources/README.md)

--- a/src/packages/README.md
+++ b/src/packages/README.md
@@ -1,14 +1,25 @@
 # Third-party packages
 
 CheriBSD on Morello ships with both hybrid ABI and CheriABI packages
-(compilations) of the FreeBSD ports collection, each targeting a different
+(compilations) of the CheriBSD ports collection, each targeting a different
 form of code generation and Application Binary Interface (ABI).
 They have different levels of completeness, maturity, security, and support.
+
+[CheriBSD ports](https://github.com/CTSRD-CHERI/cheribsd-ports)
+extend FreeBSD ports, a collection of over 30,000 third-party
+software adaptations to FreeBSD, with CHERI- and CheriBSD-specific patches.
+The
+[releng/22.12](https://github.com/CTSRD-CHERI/cheribsd-ports/tree/releng/22.12)
+CheriBSD ports branch contains ports matching packages built for the current
+release.
 
 ## Overview
 
 The following table presents an overview of available package managers in
 CheriBSD that are described in more details in consecutive sections.
+You can also browse package repositories at
+[pkg.CheriBSD.org](https://pkg.CheriBSD.org/)
+to check what packages are available for a specific ABI version.
 
 | ABI        | #       | Manager | Install path   | Suitable for     | Examples |
 |------------|---------|---------|----------------|------------------|----------|

--- a/src/packages/README.md
+++ b/src/packages/README.md
@@ -85,11 +85,6 @@ By default `/usr/local64/bin` and `/usr/local64/sbin` should be included in your
 If you are planning to use a custom shell, remember to add these paths to
 `PATH`.
 
-*Note:* Because these packages are installed in a non-standard location,
-there may be bugs related to them looking in `/usr/local` instead of
-`/usr/local64` for dependencies. Please report bugs of this sort in
-the [CheriBSD ports issue tracker](https://github.com/CTSRD-CHERI/cheribsd-ports/issues).
-
 ## CheriABI packages
 
 **CheriABI packages** are compiled using pure-capability CHERI C/C++, and
@@ -115,58 +110,3 @@ There are currently over 8,000 CheriABI packages available, including:
 
 The packages are installed in the standard `/usr/local` hierarchy as they match
 the base system ABI.
-
-*Note:* These packages compile, but many have CHERI-related warnings that
-have not been audited and only a limited set have been tested. Bugs related to
-CHERI support can be reported in the [CheriBSD ports issue
-tracker](https://github.com/CTSRD-CHERI/cheribsd-ports/issues).
-While the CheriABI packages are more interesting as they use CHERI memory-safety
-features, you must remember that they might break in run-time and hence might
-not be suitable for critical operations.
-In such case, a corresponding hybrid ABI package might be considered instead of
-a CheriABI package.
-
-## Cross-ABI package conflicts
-
-Hybrid ABI and CheriABI package repositories include many counterpart packages,
-e.g. `git` is available in both repositories.
-If you decided to use a CheriABI package and find that it crashes, you
-might consider using a hybrid ABI package instead.
-
-CheriABI packages have a higher priority than the hybrid ABI packages in default
-`PATH` environment variables in CheriBSD.
-In case you installed a CheriABI package and a hybrid ABI package with a
-conflicting program name, you must execute the hybrid ABI program using
-an absolute path.
-
-## Cross-ABI package dependencies
-
-At the moment, a package cannot depend in run-time on another package with
-a different ABI, e.g. to execute a program provided by that package.
-Such feature would be useful if a CheriBSD port cannot easily be adapted to
-CheriABI and includes a program that is executed by another port that has
-a CheriABI package.
-There are currently no plans to support this case.
-
-## Missing packages
-
-Hybrid ABI and CheriABI package repositories might be missing third-party
-software due to the following reasons:
-
-* There is no FreeBSD port including that software or it is broken on AArch64;
-
-  Check [FreshPorts](https://www.freshports.org/),
-  [FreeBSD Wiki](https://wiki.freebsd.org/WantedPorts),
-  [FreeBSD Bugzilla](https://bugs.freebsd.org/bugzilla/) and
-  the [freebsd-ports mailing
-  list](https://lists.freebsd.org/subscription/freebsd-ports) to find out
-  if anyone is working on software you are interested in.
-
-* A CheriBSD port with the software is broken on Morello or is not adapted to
-CheriABI.
-
-  Check the [CheriBSD ports issue
-  tracker](https://github.com/CTSRD-CHERI/cheribsd-ports/issues) to find out if
-  an issue with the software is documented and the [Poudriere infrastructure for
-  CheriBSD packages](https://poudriere.cheribsd.org) to find failed build
-  results.

--- a/src/packages/commands.md
+++ b/src/packages/commands.md
@@ -1,0 +1,74 @@
+# Useful commands
+
+The following list includes useful commands to manage packages.
+Replace `<pkg>` with `pkg64c` to execute a command in the context of CheriABI
+packages and with `pkg64` in the context of hybrid ABI packages.
+
+Most `pkg` commands have separate man pages describing them.
+For a command `<pkg> foo`, you can read its man page by executing `man pkg-foo`
+on a CheriBSD host.
+
+* List available package manager commands:
+  ```
+  <pkg> help
+  ```
+* Read more information on a package manager command:
+  ```
+  <pkg> help <command>
+  ```
+* Search a package repository:
+  ```
+  <pkg> search <pattern>
+  ```
+* Search a package repository and display full information:
+  ```
+  <pkg> search --full <pattern>
+  ```
+* List installed packages:
+  ```
+  <pkg> info
+  ```
+* Display information for an installed package:
+  ```
+  <pkg> info <pkg-name>
+  ```
+* Install a package:
+  ```
+  <pkg> install <pkg-name>
+  ```
+* Delete a package:
+  ```
+  <pkg> delete <pkg-name>
+  ```
+* Delete packages that are no longer required:
+  ```
+  <pkg> autoremove
+  ```
+* Check a new package version for an installed package:
+  ```
+  <pkg> upgrade -n <pkg-name>
+  ```
+* Check new package versions for all installed packages:
+  ```
+  <pkg> upgrade -n
+  ```
+* Upgrade a package after confirmation:
+  ```
+  <pkg> upgrade <pkg-name>
+  ```
+* Upgrade all packages after confirmation:
+  ```
+  <pkg> upgrade
+  ```
+* Display which package installed a file:
+  ```
+  <pkg> which /path/to/file
+  ```
+* Check a number of installed packages:
+  ```
+  <pkg> stats -l
+  ```
+* Check a number of available packages:
+  ```
+  <pkg> stats -r
+  ```

--- a/src/packages/limitations.md
+++ b/src/packages/limitations.md
@@ -46,26 +46,3 @@ Such feature would be useful if a CheriBSD port cannot easily be adapted to
 CheriABI and includes a program that is executed by another port that has
 a CheriABI package.
 There are currently no plans to support this case.
-
-## Missing packages
-
-Hybrid ABI and CheriABI package repositories might be missing third-party
-software due to the following reasons:
-
-* There is no FreeBSD port including that software or it is broken on AArch64;
-
-  Check [FreshPorts](https://www.freshports.org/),
-  [FreeBSD Wiki](https://wiki.freebsd.org/WantedPorts),
-  [FreeBSD Bugzilla](https://bugs.freebsd.org/bugzilla/) and
-  the [freebsd-ports mailing
-  list](https://lists.freebsd.org/subscription/freebsd-ports) to find out
-  if anyone is working on software you are interested in.
-
-* A CheriBSD port with the software is broken on Morello or is not adapted to
-CheriABI.
-
-  Check the [CheriBSD ports issue
-  tracker](https://github.com/CTSRD-CHERI/cheribsd-ports/issues) to find out if
-  an issue with the software is documented and the [Poudriere infrastructure for
-  CheriBSD packages](https://poudriere.cheribsd.org) to find failed build
-  results.

--- a/src/packages/limitations.md
+++ b/src/packages/limitations.md
@@ -1,42 +1,69 @@
 # Limitations of packages
 
 When using or even considering third-party software delivered with CheriBSD
-packages, it is important to keep in mind potential conflicts between hybrid ABI
-and CheriABI packages as well as limited access to software adapted to CHERI
-platforms.
+packages, it is important to keep in mind the maturity of currently available
+CheriABI packages and potential conflicts between hybrid ABI and CheriABI
+packages.
 The following sections describe some of such limitations.
 
 ## Maturity of CheriABI packages
 
-*Note:* These packages compile, but many have CHERI-related warnings that
-have not been audited and only a limited set have been tested. Bugs related to
-CHERI support can be reported in the [CheriBSD ports issue
-tracker](https://github.com/CTSRD-CHERI/cheribsd-ports/issues).
+There are many projects that must still be ported to CHERI in order to provide
+a fully functional CheriABI package repository.
+The available CheriABI packages are also not continuously tested as part of the
+CheriBSD package building infrastructure.
+
+CheriABI packages compile, but many have CHERI-related warnings that
+have not been audited and only a limited set have been tested.
 While the CheriABI packages are more interesting as they use CHERI memory-safety
 features, you must remember that they might break in run-time and hence might
 not be suitable for critical operations.
 In such case, a corresponding hybrid ABI package might be considered instead of
 a CheriABI package.
 
+We expect the number of available and tested packages to grow with future
+CheriBSD releases but it will take quite some time until we will be able to
+provide a CheriABI package repository that would include all packages currently
+provided with the hybrid ABI package repository.
+
+We encourage everyone to report bugs related to CHERI support in the
+[CheriBSD ports issue tracker](https://github.com/CTSRD-CHERI/cheribsd-ports/issues).
+
 ## Separate local bases for ABIs
 
-*Note:* Because these packages are installed in a non-standard location,
-there may be bugs related to them looking in `/usr/local` instead of
-`/usr/local64` for dependencies. Please report bugs of this sort in
-the [CheriBSD ports issue tracker](https://github.com/CTSRD-CHERI/cheribsd-ports/issues).
+Upstream FreeBSD does not have any notion of an ABI at the package manager
+level and installs all packages in the default local base path (`/usr/local`).
+CheriBSD introduces a workaround for this issue by using separate local base
+paths for different package repositories.
+
+The hybrid ABI packages are compiled with a local base set to `/usr/local64`
+while the CheriABI packages use the default local base.
+Because the hybrid ABI packages are installed in a non-standard location, there
+may be bugs resulting in hybrid ABI packages looking for its dependencies in
+`/usr/local` instead of `/usr/local64`.
+For example, a CheriBSD port a package was built from might not configure
+a project-specific build system to use a custom local base or an upstream
+project might hardcode `/usr/local` in its source code.
+
+We encourage everyone to report bugs related to invalid local base paths in the
+hybrid ABI packages in
+[CheriBSD ports issue tracker](https://github.com/CTSRD-CHERI/cheribsd-ports/issues).
 
 ## Cross-ABI package conflicts
 
 Hybrid ABI and CheriABI package repositories include many counterpart packages,
 e.g. `git` is available in both repositories.
-If you decided to use a CheriABI package and find that it crashes, you
-might consider using a hybrid ABI package instead.
-
 CheriABI packages have a higher priority than the hybrid ABI packages in default
 `PATH` environment variables in CheriBSD.
 In case you installed a CheriABI package and a hybrid ABI package with a
 conflicting program name, you must execute the hybrid ABI program using
 an absolute path.
+
+When using a shell configuration not included in CheriBSD's source code, a user
+must remember to appropriately set the `PATH` environment variable to take into
+account both `/usr/local` and `/usr/local64` paths.
+It is also recommended to place `/usr/local` before `/usr/local64` in such
+configuration to match the CheriBSD's approach.
 
 ## Cross-ABI package dependencies
 

--- a/src/packages/limitations.md
+++ b/src/packages/limitations.md
@@ -1,0 +1,71 @@
+# Limitations of packages
+
+When using or even considering third-party software delivered with CheriBSD
+packages, it is important to keep in mind potential conflicts between hybrid ABI
+and CheriABI packages as well as limited access to software adapted to CHERI
+platforms.
+The following sections describe some of such limitations.
+
+## Maturity of CheriABI packages
+
+*Note:* These packages compile, but many have CHERI-related warnings that
+have not been audited and only a limited set have been tested. Bugs related to
+CHERI support can be reported in the [CheriBSD ports issue
+tracker](https://github.com/CTSRD-CHERI/cheribsd-ports/issues).
+While the CheriABI packages are more interesting as they use CHERI memory-safety
+features, you must remember that they might break in run-time and hence might
+not be suitable for critical operations.
+In such case, a corresponding hybrid ABI package might be considered instead of
+a CheriABI package.
+
+## Separate local bases for ABIs
+
+*Note:* Because these packages are installed in a non-standard location,
+there may be bugs related to them looking in `/usr/local` instead of
+`/usr/local64` for dependencies. Please report bugs of this sort in
+the [CheriBSD ports issue tracker](https://github.com/CTSRD-CHERI/cheribsd-ports/issues).
+
+## Cross-ABI package conflicts
+
+Hybrid ABI and CheriABI package repositories include many counterpart packages,
+e.g. `git` is available in both repositories.
+If you decided to use a CheriABI package and find that it crashes, you
+might consider using a hybrid ABI package instead.
+
+CheriABI packages have a higher priority than the hybrid ABI packages in default
+`PATH` environment variables in CheriBSD.
+In case you installed a CheriABI package and a hybrid ABI package with a
+conflicting program name, you must execute the hybrid ABI program using
+an absolute path.
+
+## Cross-ABI package dependencies
+
+At the moment, a package cannot depend in run-time on another package with
+a different ABI, e.g. to execute a program provided by that package.
+Such feature would be useful if a CheriBSD port cannot easily be adapted to
+CheriABI and includes a program that is executed by another port that has
+a CheriABI package.
+There are currently no plans to support this case.
+
+## Missing packages
+
+Hybrid ABI and CheriABI package repositories might be missing third-party
+software due to the following reasons:
+
+* There is no FreeBSD port including that software or it is broken on AArch64;
+
+  Check [FreshPorts](https://www.freshports.org/),
+  [FreeBSD Wiki](https://wiki.freebsd.org/WantedPorts),
+  [FreeBSD Bugzilla](https://bugs.freebsd.org/bugzilla/) and
+  the [freebsd-ports mailing
+  list](https://lists.freebsd.org/subscription/freebsd-ports) to find out
+  if anyone is working on software you are interested in.
+
+* A CheriBSD port with the software is broken on Morello or is not adapted to
+CheriABI.
+
+  Check the [CheriBSD ports issue
+  tracker](https://github.com/CTSRD-CHERI/cheribsd-ports/issues) to find out if
+  an issue with the software is documented and the [Poudriere infrastructure for
+  CheriBSD packages](https://poudriere.cheribsd.org) to find failed build
+  results.

--- a/src/packages/missing.md
+++ b/src/packages/missing.md
@@ -1,0 +1,21 @@
+# Missing packages
+
+Hybrid ABI and CheriABI package repositories might be missing third-party
+software due to the following reasons:
+* There is no FreeBSD port including that software or it is broken on AArch64;
+
+  Check [FreshPorts](https://www.freshports.org/),
+  [FreeBSD Wiki](https://wiki.freebsd.org/WantedPorts),
+  [FreeBSD Bugzilla](https://bugs.freebsd.org/bugzilla/) and
+  the [freebsd-ports mailing
+  list](https://lists.freebsd.org/subscription/freebsd-ports) to find out
+  if anyone is working on software you are interested in.
+
+* A CheriBSD port with the software is broken on Morello or is not adapted to
+CheriABI.
+
+  Check the [CheriBSD ports issue
+  tracker](https://github.com/CTSRD-CHERI/cheribsd-ports/issues) to find out if
+  an issue with the software is documented and the [Poudriere infrastructure for
+  CheriBSD packages](https://poudriere.cheribsd.org) to find failed build
+  results.

--- a/src/packages/missing.md
+++ b/src/packages/missing.md
@@ -11,8 +11,9 @@ software due to the following reasons:
   list](https://lists.freebsd.org/subscription/freebsd-ports) to find out
   if anyone is working on software you are interested in.
 
-* A CheriBSD port with the software is broken on Morello or is not adapted to
-CheriABI.
+* A CheriBSD port with the software is broken on Morello, does not respect a
+  custom local base (`/usr/local64`) when compiled for the hybrid ABI or is not
+  adapted to CheriABI.
 
   Check the [CheriBSD ports issue
   tracker](https://github.com/CTSRD-CHERI/cheribsd-ports/issues) to find out if

--- a/src/packages/upgrading.md
+++ b/src/packages/upgrading.md
@@ -1,0 +1,46 @@
+# Upgrading packages
+
+It is recommended to upgrade packages in the following situations:
+
+* Before building a newer CheriBSD release;
+
+  The release might require an updated toolchain (e.g., due to ABI changes in
+  the release that must by supported by the toolchain).
+
+* After updating your host to a newer CheriBSD release;
+
+  A package repository for the release is compiled against an ABI version
+  supported by the newer release that might have changed since its prior
+  release.
+
+  Where practical, we intend to support packages from the immediately prior
+  release on the newer release, but will make no effort to ensure that package
+  repositories from even older releases continue to work.
+
+  Additionally, the package repository for the newer release will most likely
+  include updated third-party software versions that are tested against that
+  release.
+
+* After finding a bug in a package (e.g., a library, a toolchain).
+
+  It might happen that the bug you discovered has already been reported and
+  fixed.
+  If the package upgrade does not resolve your issue, please
+  [report the bug](../support/).
+
+Use the following commands to upgrade your packages:
+
+| CheriABI         | Hybrid ABI      |
+|------------------|-----------------|
+| `pkg64c upgrade` | `pkg64 upgrade` |
+
+If you do not want perform the upgrade itself but only check if newer versions
+are available, you can add the `-n` flag to do so:
+
+| CheriABI            | Hybrid ABI         |
+|---------------------|--------------------|
+| `pkg64c upgrade -n` | `pkg64 upgrade -n` |
+
+You can read more on the `upgrade` command at
+[pkg-upgrade(8)](https://www.freebsd.org/cgi/man.cgi?pkg-upgrade(8))
+or in your console with `man pkg-upgrade`.


### PR DESCRIPTION
Describe how packages are associated with particular CheriBSD versions and how to upgrade them. Also, move issues with packages to a separate section to make information easier to read and describe useful package manager commands a user might consider.