### PR TITLE
Bump version to 23.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- ANCHOR: cover -->
 
-# Getting Started with CheriBSD 22.12
+# Getting Started with CheriBSD 23.11
 
 Robert N. M. Watson (University of Cambridge)
 and
@@ -15,7 +15,7 @@ further information and support.
 <!--
 NOTE: A release version is also in SUMMARY.md.
 -->
-**The document describes CheriBSD as of the 22.12 release, unless explicitly
+**The document describes CheriBSD as of the 23.11 release, unless explicitly
 stated in sections referring to earlier or later releases.**
 
 *This document is a work-in-progress.  Feedback and contributions are

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- ANCHOR: cover -->
 
-# Getting Started with CheriBSD
+# Getting Started with CheriBSD 22.12
 
 Robert N. M. Watson (University of Cambridge)
 and

--- a/book.toml
+++ b/book.toml
@@ -3,7 +3,7 @@ authors = ["Robert N. M. Watson"]
 language = "en"
 multilingual = false
 src = "src"
-title = "Getting Started with CheriBSD"
+title = "Getting Started with CheriBSD 22.12"
 
 [output.html]
 git-repository-url = "https://github.com/CTSRD-CHERI/cheribsd-getting-started"

--- a/book.toml
+++ b/book.toml
@@ -3,7 +3,7 @@ authors = ["Robert N. M. Watson"]
 language = "en"
 multilingual = false
 src = "src"
-title = "Getting Started with CheriBSD 22.12"
+title = "Getting Started with CheriBSD 23.11"
 
 [output.html]
 git-repository-url = "https://github.com/CTSRD-CHERI/cheribsd-getting-started"

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,6 +1,6 @@
 # Summary
 
-[Getting Started with CheriBSD 22.12](cover/README.md)
+[Getting Started with CheriBSD 23.11](cover/README.md)
 
 - [Introduction](introduction/README.md)
 - [Background](background/README.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,6 +1,6 @@
 # Summary
 
-[Getting Started with CheriBSD](cover/README.md)
+[Getting Started with CheriBSD 22.12](cover/README.md)
 
 - [Introduction](introduction/README.md)
 - [Background](background/README.md)
@@ -29,8 +29,3 @@
 - [Benchmarking guidance](benchmarking/README.md)
 - [Getting help](support/README.md)
 - [Resources](resources/README.md)
-
-<!--
-NOTE: A release version is also in README.md.
--->
-[Current release: 22.12]()

--- a/src/features/c18n.md
+++ b/src/features/c18n.md
@@ -14,5 +14,5 @@ CHERI-enabled software compartmentalization models:
   within a process using CHERI capabilities limiting the access of attackers
   who have achieved arbitrary code execution within a library.
   Initial support for linker-based library compartmentalization is included
-  in the 22.12 release of CheriBSD.  See the compartmentalization(7) manual
+  in the 23.11 release of CheriBSD.  See the compartmentalization(7) manual
   page on an installed system for more information.

--- a/src/features/c18n.md
+++ b/src/features/c18n.md
@@ -13,6 +13,7 @@ CHERI-enabled software compartmentalization models:
 - **Dynamic-linker-based compartmentalization** isolates shared libraries
   within a process using CHERI capabilities limiting the access of attackers
   who have achieved arbitrary code execution within a library.
-  Initial support for linker-based library compartmentalization is included
-  in the 23.11 release of CheriBSD.  See the compartmentalization(7) manual
-  page on an installed system for more information.
+  The linker-based library compartmentalization model has been included since
+  the 22.12 release of CheriBSD.
+  See the compartmentalization(7) manual page on an installed system for more
+  information.

--- a/src/features/desktop.md
+++ b/src/features/desktop.md
@@ -1,6 +1,6 @@
 # CheriABI desktop environment (experimental)
 
-As of the 22.12 release, the installer has gained the option to install a
+As of the 23.11 release, the installer has gained the option to install a
 desktop environment using the Mali Bifrost GPU on the Morello System-on-Chip.
 The option installs a basic desktop environment using KDE and Wayland
 compiled for CheriABI with the `cheri-desktop` package.  It also

--- a/src/features/desktop.md
+++ b/src/features/desktop.md
@@ -1,8 +1,8 @@
 # CheriABI desktop environment (experimental)
 
-As of the 23.11 release, the installer has gained the option to install a
-desktop environment using the Mali Bifrost GPU on the Morello System-on-Chip.
-The option installs a basic desktop environment using KDE and Wayland
-compiled for CheriABI with the `cheri-desktop` package.  It also
-installs a hybrid ABI Chromium web browser via the `cheri-desktop-hybrid-extras`
-package.
+The installer has the option to install a desktop environment using the Mali
+Bifrost GPU on the Morello System-on-Chip.
+The option installs a basic desktop environment using KDE and Wayland compiled
+for CheriABI with the `cheri-desktop` package.
+It also installs a hybrid ABI Chromium web browser via the
+`cheri-desktop-hybrid-extras` package.

--- a/src/features/desktop.md
+++ b/src/features/desktop.md
@@ -4,5 +4,5 @@ As of the 23.11 release, the installer has gained the option to install a
 desktop environment using the Mali Bifrost GPU on the Morello System-on-Chip.
 The option installs a basic desktop environment using KDE and Wayland
 compiled for CheriABI with the `cheri-desktop` package.  It also
-installs a hybrid ABI Firefox web browser via the `cheri-desktop-hybrid-extras`
+installs a hybrid ABI Chromium web browser via the `cheri-desktop-hybrid-extras`
 package.

--- a/src/nonfeatures/README.md
+++ b/src/nonfeatures/README.md
@@ -11,7 +11,7 @@ Many other kernel features are not yet well validated, including:
 
 ## Alpha ZFS support
 
-The 22.12 release includes Alpha support for the ZFS file system.  It is
+The 23.11 release includes Alpha support for the ZFS file system.  It is
 lightly tested, but works without known issues with a hybrid kernel.  With
 the pure capability kernel, filesystems can be created and used, but it must
 not be the root file system as it currently hangs on boot.


### PR DESCRIPTION
There are three remaining places that must be updated *after* the release:
```
% grep -RI 22.12 src 
src/downloading/README.md:unxz cheribsd-memstick-arm64-aarch64c-22.12.img.xz
src/packages/README.md:[releng/22.12](https://github.com/CTSRD-CHERI/cheribsd-ports/tree/releng/22.12)
src/morello-install/README.md:dd if=cheribsd-memstick-arm64-aarch64c-22.12.img of=/dev/DISK bs=1048576
% 
```