### PR TITLE
Update c18n documentation

### DIFF
--- a/src/features/c18n.md
+++ b/src/features/c18n.md
@@ -10,20 +10,20 @@ CHERI-enabled software compartmentalization models:
   development branch and is not included in current software releases.
   For more information see the [Colocation Tutorial](https://github.com/CTSRD-CHERI/cheripedia/wiki/Colocation-Tutorial)
   wiki page.
-- **Dynamic-linker-based compartmentalization** isolates shared libraries
+- **Dynamic-linkage-based compartmentalization** isolates shared libraries
   within a process using CHERI capabilities limiting the access of attackers
   who have achieved arbitrary code execution within a library.
-  The linker-based library compartmentalization model has been included since
+  The linkage-based compartmentalization prototype has been included since
   the 22.12 release of CheriBSD.
   See the [c18n(3) man
   page](https://man.cheribsd.org/cgi-bin/man.cgi/releng-25.03/c18n)
   on an installed system for more information.
 
-## Library compartmentalization
+## Linkage-based compartmentalization
 
-CheriBSD's library compartmentalization feature (c18n) executes each dynamic
-library within a compartmentalization-enabled process in its own protection
-domain.
+CheriBSD's linkage-based compartmentalization feature (c18n) executes each
+dynamic library within a compartmentalization-enabled process in its own
+protection domain.
 When c18n is enabled, the run-time linker grants libraries capabilities only
 to resources (global variables, APIs) declared in their ELF linkage.
 Function calls that cross domain boundaries are interposed on by
@@ -33,8 +33,8 @@ The adversary model for these compartments is one of trusted code but
 untrustworthy execution: a library such as `libpng` or `libjpeg` is trusted
 until it begins dynamic execution -- and has potentially been exposed to
 malicious data.
-With library compartmentalization, an adversary who achieves arbitrary code
-execution within the library at run time will be able to reach only the
+With linkage-based compartmentalization, an adversary who achieves arbitrary
+code execution within the library at run time will be able to reach only the
 resources (and further attack surfaces) declared statically through its
 linkage.
 The programmer must then harden that linkage, and any involved APIs, to make
@@ -42,22 +42,16 @@ them suitable for adversarial engagement -- but the foundation of isolation,
 controlled access, and controlled domain transition is provided by the c18n
 implementation.
 
-In addition to a modified run-time linker, modest changes have been made to
-the aarch64c calling convention to avoid assumptions such as implicit stack
-sharing between callers and callees across library boundaries when passing
-variadic argument lists.
-This modified ABI is now used by all CheriABI binaries in CheriBSD, and so
-off-the-shelf aarch64c binaries and libraries can be used with library
-compartmentalization without recompilation to the modified ABI.
-More information on library compartmentalization can be found in the
-[c18n(3) man
+Note that linkage-based compartmentalization is still an experimental work
+in progress and does not yet provide complete isolation between compartments.
+More information on security caveats can be found in the [c18n(3) man
 page](https://man.cheribsd.org/cgi-bin/man.cgi/releng-25.03/c18n):
 
 ```
 man c18n
 ```
 
-## Enabling library compartmentalization system-wide
+## Enabling linkage-based compartmentalization system-wide
 
 Compartmentalization can be enabled for all eligible new processes with
 `sysctl`:
@@ -66,19 +60,19 @@ Compartmentalization can be enabled for all eligible new processes with
 sysctl security.cheri.lib_based_c18n_default=1
 ```
 
-## Enabling library compartmentalization temporarily for a particular binary
+## Enabling linkage-based compartmentalization temporarily for a particular binary
 
-To run a particular binary with library compartmentalization enabled just for
-this run, use `proccontrol`:
+To run a particular binary with linkage-based compartmentalization enabled
+just for this run, use `proccontrol`:
 
 ```
 proccontrol -m cheric18n -s enable ./helloworld
 ```
 
-## Enabling library compartmentalization permanently for a particular binary
+## Enabling linkage-based compartmentalization permanently for a particular binary
 
-To enable library compartmentalization permanently for a particular binary,
-run the following command to set a flag in the binary:
+To enable linkage-based compartmentalization permanently for a particular
+binary, run the following command to set a flag in the binary:
 
 ```
 elfctl -e +cheric18n ./helloworld
@@ -138,7 +132,7 @@ With this in mind, you can:
  * Consider larger software architectural changes that will allow a library
    to be used more robustly when running within a computerment.
 
-Library compartmentalization has the potential to significantly improve
+Linkage-based compartmentalization has the potential to significantly improve
 software integrity and confidentiality properties in the presence of a strong
 adversary.
 However, it is also limited by the abstraction being around the current

--- a/src/features/c18n.md
+++ b/src/features/c18n.md
@@ -44,7 +44,7 @@ implementation.
 
 Note that linkage-based compartmentalization is still an experimental work
 in progress and does not yet provide complete isolation between compartments.
-More information on security caveats can be found in the [c18n(3) man
+More information on security caveats can be found in the [c18n(7) man
 page](https://man.cheribsd.org/cgi-bin/man.cgi/releng-25.03/c18n):
 
 ```


### PR DESCRIPTION
Rename 'library compartmentalization' to 'linkage-based compartmentalization'. Remove discussion about the new ABI as the old ABI has been fully phased out. Emphasize the experimental nature of c18n and point to man page for caveats.