### PR TITLE
Update install instructions and helloworld for 26.07 and bump versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- ANCHOR: cover -->
 
-# Getting Started with CheriBSD 25.03
+# Getting Started with CheriBSD 26.07
 
 Robert N. M. Watson (University of Cambridge),
 Jessica Clarke (University of Cambridge),
@@ -18,7 +18,7 @@ further information and support.
 <!--
 NOTE: A release version is also in SUMMARY.md.
 -->
-**The document describes CheriBSD as of the 25.03 release, unless explicitly
+**The document describes CheriBSD as of the 26.07 release, unless explicitly
 stated in sections referring to earlier or later releases.**
 
 *This document is a work-in-progress.  Feedback and contributions are

--- a/book.toml
+++ b/book.toml
@@ -3,7 +3,7 @@ authors = ["Robert N. M. Watson"]
 language = "en"
 multilingual = false
 src = "src"
-title = "Getting Started with CheriBSD 25.03"
+title = "Getting Started with CheriBSD 26.07"
 
 [output.html]
 git-repository-url = "https://github.com/CTSRD-CHERI/cheribsd-getting-started"

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -1,6 +1,6 @@
 # Summary
 
-[Getting Started with CheriBSD 25.03](cover/README.md)
+[Getting Started with CheriBSD 26.07](cover/README.md)
 
 - [Introduction](introduction/README.md)
 - [Background](background/README.md)
@@ -15,6 +15,7 @@
 - [Getting CheriBSD](getting/README.md)
   - [Downloading image files](downloading/README.md)
   - [Building image files](building/README.md)
+  - [Updating an existing system](updating/README.md)
 - [CheriBSD on an Arm Morello board](morello/README.md)
   - [Accessing the Morello console](morello-console/README.md)
   - [Upgrading the Morello firmware](morello-firmware/README.md)

--- a/src/downloading/README.md
+++ b/src/downloading/README.md
@@ -6,5 +6,5 @@ Images are compressed using the UNIX `xz` command, and must be decompressed
 before they can be used; for example by running:
 
 ```
-unxz cheribsd-memstick-arm64-aarch64c-25.03.img.xz
+unxz cheribsd-memstick-arm64-aarch64c-26.07.img.xz
 ````

--- a/src/features/c18n.md
+++ b/src/features/c18n.md
@@ -16,7 +16,7 @@ CHERI-enabled software compartmentalization models:
   The linkage-based compartmentalization prototype has been included since
   the 22.12 release of CheriBSD.
   See the [c18n(3) man
-  page](https://man.cheribsd.org/cgi-bin/man.cgi/releng-25.03/c18n)
+  page](https://man.cheribsd.org/cgi-bin/man.cgi/releng-26.07/c18n)
   on an installed system for more information.
 
 ## Linkage-based compartmentalization
@@ -45,7 +45,7 @@ implementation.
 Note that linkage-based compartmentalization is still an experimental work
 in progress and does not yet provide complete isolation between compartments.
 More information on security caveats can be found in the [c18n(7) man
-page](https://man.cheribsd.org/cgi-bin/man.cgi/releng-25.03/c18n):
+page](https://man.cheribsd.org/cgi-bin/man.cgi/releng-26.07/c18n):
 
 ```
 man c18n

--- a/src/features/processes.md
+++ b/src/features/processes.md
@@ -1,6 +1,6 @@
 # Userlevel process environments
 
-CheriBSD 25.03 likewise supports three different userspace execution
+CheriBSD 26.07 likewise supports three different userspace execution
 environments:
 
 - **Hybrid processes** provide strong binary compatibility with the non-CHERI

--- a/src/helloworld/README.md
+++ b/src/helloworld/README.md
@@ -10,7 +10,9 @@ details and registers in GDB will differ.
 You will need the Morello LLVM toolchain and Morello GDB for this
 exercise. To install LLVM, use the command:
 
-```pkg64 install llvm-base```
+```
+pkg64 install llvm-base
+```
 
 If this is the first time you are using `pkg64` on this system, you will
 be prompted to bootstrap the `pkg` package before the package database
@@ -21,52 +23,40 @@ and its dependencies:
 root@cheribsd:~ # pkg64 install llvm-base
 The package management tool is not yet installed on your system.
 Do you want to fetch and install it now? [y/N]: y
-Bootstrapping pkg from pkg+http://pkg.CheriBSD.org/CheriBSD:20220314:aarch64, please wait...
+Bootstrapping pkg from http://pkg.CheriBSD.org/CheriBSD:20260710:aarch64, please wait...
 Verifying signature with trusted certificate pkg.cheribsd.org.2022032901... done
-Installing pkg-1.17.5_1...
-Extracting pkg-1.17.5_1: 100%
+Installing pkg-1.20.5_1...
+Extracting pkg-1.20.5_1: 100%
 Updating CheriBSD repository catalogue...
-Fetching meta.conf: 100%    163 B   0.2kB/s    00:01
-Fetching packagesite.pkg: 100%    4 MiB   1.4MB/s    00:03
+Fetching meta.conf: 100%    179 B   0.2kB/s    00:01
+Fetching packagesite.pkg: 100%    7 MiB   7.2MB/s    00:01
 Processing entries: 100%
-CheriBSD repository update completed. 20954 packages processed.
+CheriBSD repository update completed. 26229 packages processed.
 All repositories are up to date.
 Updating database digests format: 100%
-The following 12 package(s) will be affected (of 0 checked):
+The following 3 package(s) will be affected (of 0 checked):
 
 New packages to be INSTALLED:
-        gettext-runtime: 0.21
-        indexinfo: 0.3.1
-        libedit: 3.1.20210910,1
-        libffi: 3.3_1
-        libxml2: 2.9.13_2
-        llvm: 13,1
-        llvm-base: 1
-        llvm-morello: 13.0.d20220502_1
-        mpdecimal: 2.5.1
-        perl5: 5.32.1_1
-        python38: 3.8.13
-        readline: 8.1.2
+        llvm: 17,1
+        llvm-base: 20240315
+        llvm-morello: 17.0.d20260205_4
 
-Number of packages to be installed: 12
+Number of packages to be installed: 3
 
-The process will require 902 MiB more space.
-190 MiB to be downloaded.
+The process will require 818 MiB more space.
+116 MiB to be downloaded.
 
 Proceed with this action? [y/N]: y
-[1/12] Fetching llvm-base-1.pkg: 100%    3 KiB   2.8kB/s    00:01
-[2/12] Fetching llvm-13,1.pkg: 100%   11 KiB  11.2kB/s    00:01
-...
-[12/12] Fetching libedit-3.1.20210910,1.pkg: 100%  119 KiB 121.8kB/s    00:01
+[1/3] Fetching llvm-base-20240315.pkg: 100%    1 KiB   1.1kB/s    00:01
+[2/3] Fetching llvm-morello-17.0.d20260205_4.pkg: 100%  116 MiB  60.8MB/s    00:02
+[3/3] Fetching llvm-17,1.pkg: 100%   12 KiB  11.8kB/s    00:01
 Checking integrity... done (0 conflicting)
-[1/12] Installing indexinfo-0.3.1...
-[1/12] Extracting indexinfo-0.3.1: 100%
-...
-[12/12] Installing llvm-base-1...
-[12/12] Extracting llvm-base-1: 100%
-=====
-...
-
+[1/3] Installing llvm-morello-17.0.d20260205_4...
+[1/3] Extracting llvm-morello-17.0.d20260205_4: 100%
+[2/3] Installing llvm-17,1...
+[2/3] Extracting llvm-17,1: 100%
+[3/3] Installing llvm-base-20240315...
+[3/3] Extracting llvm-base-20240315: 100%
 ```
 
 *Note:* By default FreeBSD ships with the `vi` and `ee` editors. You may
@@ -90,13 +80,15 @@ main(void)
 
 To build a CheriABI Hello World program use:
 
-```cc -g -O2 -Wall -o helloworld helloworld.c```
+```
+cc -g -O2 -Wall -o helloworld helloworld.c
+```
 
 You can verify this is a CheriABI binary with the `file` command:
 
 ```
-root@cheribsd:~ # file helloworld
-helloworld: ELF 64-bit LSB pie executable, ARM aarch64, C64, CheriABI, version 1 (SYSV), dynamically linked, interpreter /libexec/ld-elf.so.1, for FreeBSD 14.0 (1400094), FreeBSD-style, with debug_info, not stripped
+user@cheribsd:~ $ file helloworld
+helloworld: ELF 64-bit LSB pie executable, ARM aarch64, C64, CheriABI, version 1 (SYSV), dynamically linked, interpreter /libexec/ld-elf.so.1, for FreeBSD 15.0 (1500040), FreeBSD-style, with debug_info, not stripped
 ```
 
 ## Building for the Benchmark ABI
@@ -104,12 +96,14 @@ helloworld: ELF 64-bit LSB pie executable, ARM aarch64, C64, CheriABI, version 1
 To target the [Benchmark ABI](../benchmarking/), add the argument
 `-mabi=purecap-benchmark` to the `cc` command line:
 
-```cc -g -O2 -Wall -mabi=purecap-benchmark -o helloworld helloworld.c```
+```
+cc -g -O2 -Wall -mabi=purecap-benchmark -o helloworld helloworld.c
+```
 
 You can verify this is a Benchmark ABI binary with the `file` command:
 ```
-root@cheribsd:~ # file helloworld
-helloworld: ELF 64-bit LSB pie executable, ARM aarch64, C64, CheriABI, version 1 (SYSV), dynamically linked, interpreter /libexec/ld-elf.so.1, for FreeBSD 14.0 (1400094), FreeBSD-style, pure-capability benchmark ABI, with debug_info, not stripped
+user@cheribsd:~ $ file helloworld
+helloworld: ELF 64-bit LSB pie executable, ARM aarch64, C64, CheriABI, version 1 (SYSV), dynamically linked, interpreter /libexec/ld-elf.so.1, for FreeBSD 15.0 (1500040), FreeBSD-style, pure-capability benchmark ABI, with debug_info, not stripped
 ```
 
 ## Running
@@ -117,7 +111,7 @@ helloworld: ELF 64-bit LSB pie executable, ARM aarch64, C64, CheriABI, version 1
 Run the program:
 
 ```
-root@cheribsd:~ # ./helloworld
+user@cheribsd:~ $ ./helloworld
 Hello world
 ```
 
@@ -125,24 +119,26 @@ Hello world
 
 First, if it is not already installed, install the CHERI GDB debugger:
 
-```pkg64 install gdb-cheri```
+```
+pkg64 install gdb-cheri
+```
 
 You can then debug `helloworld` by running GDB and setting a breakpoint
-on `main`:
+on `main` (note the output here is for the CheriABI helloworld binary, not the
+Benchmark ABI one):
 
 ```
-root@cheribsd:~ # gdb ./helloworld
-GNU gdb (GDB) 12.1
+user@cheribsd:~ $ gdb ./helloworld
+GNU gdb (GDB) 14.1 [GDB v14.1.d20260511 for FreeBSD]
 ...
 Reading symbols from ./helloworld...
-...
 (gdb) b main
-Breakpoint 1 at 0x10a14: file helloworld.c, line 6.
+Breakpoint 1 at 0x107fc: file helloworld.c, line 6.
 (gdb) r
-Starting program: /root/helloworld
+Starting program: /home/user/helloworld
 
 Breakpoint 1, main () at helloworld.c:6
-6           printf("Hello world\n");
+6               printf("Hello world\n");
 (gdb) 
 ```
 
@@ -152,17 +148,19 @@ argument with expanded information including bounds and permissions:
 
 ```
 (gdb) s
-puts (s=0x1006e0 [rR,0x1006e0-0x1006ec] "Hello world")
-    at /home/bed22/cheri/cheribsd/lib/libc/stdio/puts.c:60
-60      /home/bed22/cheri/cheribsd/lib/libc/stdio/puts.c: No such file or directory.
+puts (s=0x100651 [rR,0x100651-0x10065d] "Hello world")
+    at /local/scratch/jenkins/workspace/CheriBSD-pipeline_releng_26.07/cheribsd/lib/libc/stdio/puts.c:54
+warning: 54     /local/scratch/jenkins/workspace/CheriBSD-pipeline_releng_26.07/cheribsd/lib/libc/stdio/puts.c: No such file or directory
 ```
-The argument can also be examined directly as either an integer or capability register:
+
+The argument can also be examined directly as either an integer or capability
+register:
+
 ```
 (gdb) info reg x0
-x0             0x1006e0            1050336
+x0             0x100651            1050193
 (gdb) info reg c0
-c0             0x905f400046ec06e000000000001006e0 0x1006e0 [rR,0x1006e0-0x1006ec]
-(gdb)
+c0             0x905c4000465d06510000000000100651 0x100651 [rR,0x100651-0x10065d]
 ```
 
 If a capability (either in memory or a register) contains a
@@ -176,33 +174,33 @@ internal FILE structure used for stdout in libc:
 
 ```
 (gdb) p *__stdoutp
-$1 = {_p = 0x0, _r = 0, _w = 0, _flags = 8, _file = 1, _bf = {_base = 0x0, 
-    _size = 0}, _lbfsize = 0, 
-  _cookie = 0x403a8400 [rwRWE,0x403a8230-0x403a87a0], 
-  _close = 0x402bade5 <__sclose> [rxRE,0x4018e000-0x407f0000] (sentry), 
-  _read = 0x402bada5 <__sread> [rxRE,0x4018e000-0x407f0000] (sentry), 
-  _seek = 0x402baddd <__sseek> [rxRE,0x4018e000-0x407f0000] (sentry), 
-  _write = 0x402badc1 <__swrite> [rxRE,0x4018e000-0x407f0000] (sentry), _ub = {
-    _base = 0x0, _size = 0}, _up = 0x0, _ur = 0, _ubuf = "\000\000", 
-  _nbuf = "", _lb = {_base = 0x0, _size = 0}, _blksize = 0, _offset = 0, 
-  _fl_mutex = 0x0, _fl_owner = 0x0, _fl_count = 0, _orientation = 0, 
-  _mbstate = {__mbstate8 = '\000' <repeats 127 times>, _mbstateL = 0, 
+$1 = {_p = 0x0, _r = 0, _w = 0, _flags = 8, _file = 1, _bf = {_base = 0x0,
+    _size = 0}, _lbfsize = 0,
+  _cookie = 0x403ec7f0 [rwRW,0x403ec620-0x403ecb90],
+  _close = 0x402dece1 <__sclose> [rxRE,0x401f1200-0x403c7000] (sentry),
+  _read = 0x402deca1 <__sread> [rxRE,0x401f1200-0x403c7000] (sentry),
+  _seek = 0x402decd9 <__sseek> [rxRE,0x401f1200-0x403c7000] (sentry),
+  _write = 0x402decbd <__swrite> [rxRE,0x401f1200-0x403c7000] (sentry), _ub = {
+    _base = 0x0, _size = 0}, _up = 0x0, _ur = 0, _ubuf = "\000\000",
+  _nbuf = "", _lb = {_base = 0x0, _size = 0}, _blksize = 0, _offset = 0,
+  _fl_mutex = 0x0, _fl_owner = 0x0, _fl_count = 0, _orientation = 0,
+  _mbstate = {__mbstate8 = '\000' <repeats 127 times>, _mbstateL = 0,
     _mbstateP = 0x0 }, _flags2 = 0}
 (gdb) x/16gxm __stdoutp
-<CHERI Tag 0 for range [0x403a8400,0x403a8410)>
-0x403a8400:     0x0000000000000000      0x0000000000000000
-<CHERI Tag 0 for range [0x403a8410,0x403a8420)>
-0x403a8410:     0x0000000000000000      0x0000000000010008
-<CHERI Tag 0 for range [0x403a8420,0x403a8430)>
-0x403a8420:     0x0000000000000000      0x0000000000000000
-<CHERI Tag 0 for range [0x403a8430,0x403a8440)>
-0x403a8430:     0x0000000000000000      0x0000000000000000
-<CHERI Tag 0 for range [0x403a8440,0x403a8450)>
-0x403a8440:     0x0000000000000000      0x0000000000000000
-<CHERI Tag 1 for range [0x403a8450,0x403a8460)>
-0x403a8450:     0x00000000403a8400      0xdc5fc00047a08230
-<CHERI Tag 1 for range [0x403a8460,0x403a8470)>
-0x403a8460:     0x00000000402bade5      0xb05fc000bf0618e7
-<CHERI Tag 1 for range [0x403a8470,0x403a8480)>
-0x403a8470:     0x00000000402bada5      0xb05fc000bf0618e7
+<CHERI Tag 0 for range [0x403ec7f0,0x403ec800)>
+0x403ec7f0:       0x0000000000000000      0x0000000000000000
+<CHERI Tag 0 for range [0x403ec800,0x403ec810)>
+0x403ec800:       0x0000000000000000      0x0000000000010008
+<CHERI Tag 0 for range [0x403ec810,0x403ec820)>
+0x403ec810:       0x0000000000000000      0x0000000000000000
+<CHERI Tag 0 for range [0x403ec820,0x403ec830)>
+0x403ec820:       0x0000000000000000      0x0000000000000000
+<CHERI Tag 0 for range [0x403ec830,0x403ec840)>
+0x403ec830:       0x0000000000000000      0x0000000000000000
+<CHERI Tag 1 for range [0x403ec840,0x403ec850)>
+0x403ec840:       0x00000000403ec7f0      0xdc5d40004b90c620
+<CHERI Tag 1 for range [0x403ec850,0x403ec860)>
+0x403ec850:       0x00000000402dece1      0xb05dc000b1c77c49
+<CHERI Tag 1 for range [0x403ec860,0x403ec870)>
+0x403ec860:       0x00000000402deca1      0xb05dc000b1c77c49
 ```

--- a/src/helloworld/README.md
+++ b/src/helloworld/README.md
@@ -153,6 +153,15 @@ puts (s=0x100651 [rR,0x100651-0x10065d] "Hello world")
 warning: 54     /local/scratch/jenkins/workspace/CheriBSD-pipeline_releng_26.07/cheribsd/lib/libc/stdio/puts.c: No such file or directory
 ```
 
+This information is also included in backtraces:
+
+```
+(gdb) bt
+#0  puts (s=0x100651 [rR,0x100651-0x10065d] "Hello world")
+    at /local/scratch/jenkins/workspace/CheriBSD-pipeline_releng_26.07/cheribsd/lib/libc/stdio/puts.c:54
+#1  0x0000000000110808 in main () at helloworld.c:6
+```
+
 The argument can also be examined directly as either an integer or capability
 register:
 
@@ -203,4 +212,141 @@ $1 = {_p = 0x0, _r = 0, _w = 0, _flags = 8, _file = 1, _bf = {_base = 0x0,
 0x403ec850:       0x00000000402dece1      0xb05dc000b1c77c49
 <CHERI Tag 1 for range [0x403ec860,0x403ec870)>
 0x403ec860:       0x00000000402deca1      0xb05dc000b1c77c49
+```
+
+Walking up the stack frames we can see the different parts of the thread's
+stack in use:
+
+```
+(gdb) info reg csp
+csp            0xdc5c40003ffdbfff0000fffffff7fe40 0xfffffff7fe40 [rwRW,0xffffbff80000-0xfffffff80000]
+(gdb) f 1
+#1  0x0000000000110808 in main () at helloworld.c:6
+6               printf("Hello world\n");
+(gdb) info reg csp
+csp            0xdc5c40003ffdbfff0000fffffff7ff60 0xfffffff7ff60 [rwRW,0xffffbff80000-0xfffffff80000]
+```
+
+## Debugging with compartmentalization
+
+By default, CheriBSD runs without linkage-based compartmentalization enabled.
+For more information on this technology, and the various ways it can be enabled
+or disabled, see [Userlevel software compartmentalization](../features/c18n.md)
+this guide.
+First, enable compartmentalization for this binary:
+
+```
+user@cheribsd:~ $ elfctl -e +cheric18n helloworld
+```
+
+Then verify it runs as before:
+
+```
+user@cheribsd:~ $ ./helloworld
+Hello world
+```
+
+Now, run it under GDB again and this time set a breakpoint on `puts` directly
+(or `printf`, depending on what function you stepped into before):
+
+```
+user@cheribsd:~ $ gdb ./helloworld
+GNU gdb (GDB) 14.1 [GDB v14.1.d20260511 for FreeBSD]
+...
+Reading symbols from ./helloworld...
+(gdb) b puts
+Function "puts" not defined.
+Make breakpoint pending on future shared library load? (y or [n]) y
+Breakpoint 1 (puts) pending.
+(gdb) r
+Starting program: /home/user/helloworld
+
+Breakpoint 1, puts (s=0x100651 [rR,0x100651-0x10065d] "Hello world")
+    at /local/scratch/jenkins/workspace/CheriBSD-pipeline_releng_26.07/cheribsd/lib/libc/stdio/puts.c:54
+warning: 54     /local/scratch/jenkins/workspace/CheriBSD-pipeline_releng_26.07/cheribsd/lib/libc/stdio/puts.c: No such file or directory
+(gdb) 
+```
+
+This time, if we look at a backtrace, there is an extra `<cross-compartment
+call>` frame, since the call from `main` to `puts` is between two different
+compartments, requiring a domain transition:
+
+```
+(gdb) bt
+#0  puts (s=0x100651 [rR,0x100651-0x10065d] "Hello world")
+    at /local/scratch/jenkins/workspace/CheriBSD-pipeline_releng_26.07/cheribsd/lib/libc/stdio/puts.c:54
+#1  <cross-compartment call>, from "/helloworld" (ID: 3) to "[TCB]" (ID: 1)
+#2  main () at helloworld.c:7
+```
+
+The `info compartments` command will list all compartments present in the
+userspace process:
+
+```
+(gdb) info compartments
+  Id Name        Libraries
+   0 [RTLD]      /libexec/ld-elf.so.1
+   1 [TCB]       libc.so.7 libthr.so.3 libsys.so.7
+   2 [libunwind] libgcc_s.so.1
+   3 /helloworld /helloworld
+```
+
+We can still inspect the argument register as before, which is unchanged:
+
+```
+(gdb) info reg x0
+x0             0x100651            1050193
+(gdb) info reg c0
+c0             0x905c4000465d06510000000000100651 0x100651 [rR,0x100651-0x10065d]
+```
+
+If we look at `__stdoutp`, the various `sentry` capabilities present before no
+longer point to the corresponding symbols (e.g. `_close` no longer points to
+`__sclose`), since these function pointers are automatically wrapped by
+trampolines to ensure any cross-compartment calls undergo a domain transition:
+
+```
+(gdb) p *__stdoutp
+$1 = {_p = 0x0, _r = 0, _w = 0, _flags = 8, _file = 1, _bf = {_base = 0x0,
+    _size = 0}, _lbfsize = 0,
+  _cookie = 0x403ed7f0 [rwRW,0x403ed620-0x403edb90],
+  _close = 0x408e752d [rxRE,0x408e7500-0x408e7668] (sentry),
+  _read = 0x408e780d [rxRE,0x408e77e0-0x408e7948] (sentry),
+  _seek = 0x408e7aed [rxRE,0x408e7ac0-0x408e7c28] (sentry),
+  _write = 0x408e797d [rxRE,0x408e7950-0x408e7ab8] (sentry), _ub = {
+    _base = 0x0, _size = 0}, _up = 0x0, _ur = 0, _ubuf = "\000\000",
+  _nbuf = "", _lb = {_base = 0x0, _size = 0}, _blksize = 0, _offset = 0,
+  _fl_mutex = 0x0, _fl_owner = 0x0, _fl_count = 0, _orientation = 0,
+  _mbstate = {__mbstate8 = '\000' <repeats 127 times>, _mbstateL = 0,
+    _mbstateP = 0x0 }, _flags2 = 0}
+(gdb) x/16gxm __stdoutp
+<CHERI Tag 0 for range [0x403ed7f0,0x403ed800)>
+0x403ed7f0:       0x0000000000000000      0x0000000000000000
+<CHERI Tag 0 for range [0x403ed800,0x403ed810)>
+0x403ed800:       0x0000000000000000      0x0000000000010008
+<CHERI Tag 0 for range [0x403ed810,0x403ed820)>
+0x403ed810:       0x0000000000000000      0x0000000000000000
+<CHERI Tag 0 for range [0x403ed820,0x403ed830)>
+0x403ed820:       0x0000000000000000      0x0000000000000000
+<CHERI Tag 0 for range [0x403ed830,0x403ed840)>
+0x403ed830:       0x0000000000000000      0x0000000000000000
+<CHERI Tag 1 for range [0x403ed840,0x403ed850)>
+0x403ed840:       0x00000000403ed7f0      0xdc5d40005b90d620
+<CHERI Tag 1 for range [0x403ed850,0x403ed860)>
+0x403ed850:       0x00000000408e752d      0xb05fc000f6687500
+<CHERI Tag 1 for range [0x403ed860,0x403ed870)>
+0x403ed860:       0x00000000408e780d      0xb05fc000f94877e0
+```
+
+We can also see that different stacks are being used between the different
+compartments, not just parts of the same single stack:
+
+```
+(gdb) info reg csp
+csp            0xdc5c40003456b4570000000040f44e80 0x40f44e80 [rwRW,0x40b45000-0x40f45000]
+(gdb) f 2
+#2  main () at helloworld.c:7
+7       }
+(gdb) info reg csp
+csp            0xdc5e40002006a0070000000041dfffc0 0x41dfffc0 [rwRW,0x41a00000-0x41e00000]
 ```

--- a/src/morello-install/README.md
+++ b/src/morello-install/README.md
@@ -7,16 +7,13 @@ Once you have a disk image, you will either need to write it to a USB stick
 to boot an Arm Morello system, or specify it as an argument to an emulator
 such as QEMU-CHERI or the Arm Morello FVP.
 
-*Note that some screen shots in these instructions are from the 24.05
-release, and will be updated soon.*
-
 ## Writing an installer disk image to a USB stick
 
 If the image file you have downloaded is compressed (i.e., has a `.xz`
 filename suffix), you will need to first decompress the image:
 
 ```
-unxz cheribsd-memstick-arm64-aarch64c-25.03.img.xz
+unxz cheribsd-memstick-arm64-aarch64c-26.07.img.xz
 ```
 
 With appropriate substitutions of image filename and target device, the
@@ -24,7 +21,7 @@ following command would write the image to a USB stick for use with a Morello
 board:
 
 ```
-dd if=cheribsd-memstick-arm64-aarch64c-25.03.img of=/dev/DISK bs=1M
+dd if=cheribsd-memstick-arm64-aarch64c-26.07.img of=/dev/DISK bs=1M
 ```
 
 It is also possible to write a live image to a USB stick, with appropriate
@@ -66,8 +63,8 @@ Enter:
 
 ```
    Select Language            <Standard English>         This selection will
-                                                         take you to the
- > Device Manager                                        Device Manager
+                                                         take you to the Boot
+ > Device Manager                                        Manager
  > Boot Manager
  > Boot Maintenance Manager
 
@@ -122,22 +119,23 @@ You can press Enter to proceed, or wait for the countdown timer to finish:
   | |    | '_ \ / _ \ '__| |  _ < \___ \| |  | |
   | |____| | | |  __/ |  | | |_) |____) | |__| |
    \_____|_| |_|\___|_|  |_|____/|_____/|_____/
-                                                 ```                        `
-                                                s` `.....---.......--.```   -/
- /---------- Welcome to CheriBSD ----------\    +o   .--`         /y:`      +.
- |                                         |     yo`:.            :o      `+-
- |  1. Boot Installer [Enter]              |      y/               -/`   -o/
- |  2. Boot Single user                    |     .-                  ::/sy+:.
- |  3. Escape to loader prompt             |     /                     `--  /
- |  4. Reboot                              |    `:                          :`
- |  5. Cons: Serial                        |    `:                          :`
- |                                         |     /                          /
- |  Options:                               |     .-                        -.
- |  6. Kernel: default/kernel (1 of 1)     |      --                      -.
- |  7. Boot Options                        |       `:`                  `:`
- |                                         |         .--             `--.
- |                                         |            .---.....----.
- \-----------------------------------------/
+
+
+ /-------- Welcome to CheriBSD ---------\  ```                        `
+ |                                      | s` `.....---.......--.```   -/
+ |  1. Boot Installer [Enter]           | +o   .--`         /y:`      +.
+ |  2. Boot Single user                 |  yo`:.            :o      `+-
+ |  3. Escape to loader prompt          |   y/               -/`   -o/
+ |  4. Reboot                           |  .-                  ::/sy+:.
+ |  5. Cons: Serial                     |  /                     `--  /
+ |                                      | `:                          :`
+ |  Kernel:                             | `:                          :`
+ |  6. kernel (1 of 1)                  |  /                          /
+ |                                      |  .-                        -.
+ |  Options:                            |   --                      -.
+ |  7. Boot Options                     |    `:`                  `:`
+ |                                      |      .--             `--.
+ \--------------------------------------/         .---.....----.
    Autoboot in 10 seconds. [Space] to pause
 ```
 
@@ -170,13 +168,13 @@ key, to select menu options, which many users find confusing.**
 
 Select **Install** at the first menu by hitting Enter:
 ```
-                   ┌────────────────┤Welcome├────────────────┐
-                   │ Welcome to FreeBSD! Would you like to   │
-                   │ begin an installation or use the live   │
-                   │ system?                                 │
-                   ├─────────────────────────────────────────┤
-                   │[  Install  ] [   Shell   ] [Live System]│
-                   └─────────────────────────────────────────┘
+                  ┌────────────────┤Welcome├────────────────┐
+                  │ Welcome to FreeBSD! Would you like to   │
+                  │ begin an installation or use the live   │
+                  │ system?                                 │
+                  ├─────────────────────────────────────────┤
+                  │[  Install  ] [   Shell   ] [Live System]│
+                  └─────────────────────────────────────────┘
 ```
 
 #### Keymap selection
@@ -185,26 +183,25 @@ If you intend only to use the serial console, and not video console, select
 the default keymap by hitting Enter at the next menu; otherwise, use the
 cursor keys and space bar to select a country-specific keyboard layout:
 ```
-       ┌───────────────────────┤Keymap Selection├────────────────────────┐
-       │ The system console driver for FreeBSD defaults to standard "US" │
-       │ keyboard map. Other keymaps can be chosen below.                │
-       │ ┌─────────────────────────────────────────────────────────────┐ │
-       │ │>>> Continue with default keymap                             │ │
-       │ │->- Test default keymap                                      │ │
-       │ │( ) Armenian phonetic layout                                 │ │
-       │ │( ) Belarusian                                               │ │
-       │ │( ) Belgian                                                  │ │
-       │ │( ) Belgian (accent keys)                                    │ │
-       │ │( ) Brazilian (accent keys)                                  │ │
-       │ │( ) Brazilian (without accent keys)                          │ │
-       │ │( ) Bulgarian (BDS)                                          │ │
-       │ │( ) Bulgarian (Phonetic)                                     │ │
-       │ │( ) Canadian Bilingual                                       │ │
-       │ └─↓↓↓──────────────────────────────────────────────────── 41%─┘ │
-       ├─────────────────────────────────────────────────────────────────┤
-       │                      [Select]     [Cancel]                      │
-       └────────────────── Press arrows, TAB or ENTER ───────────────────┘
-
+      ┌───────────────────────┤Keymap Selection├────────────────────────┐
+      │ The system console driver for FreeBSD defaults to standard "US" │
+      │ keyboard map. Other keymaps can be chosen below.                │
+      │ ┌─────────────────────────────────────────────────────────────┐ │
+      │ │>>> Continue with default keymap                             │ │
+      │ │->- Test default keymap                                      │ │
+      │ │( ) Armenian phonetic layout                                 │ │
+      │ │( ) Belarusian                                               │ │
+      │ │( ) Belgian                                                  │ │
+      │ │( ) Belgian (accent keys)                                    │ │
+      │ │( ) Brazilian (accent keys)                                  │ │
+      │ │( ) Brazilian (without accent keys)                          │ │
+      │ │( ) Bulgarian (BDS)                                          │ │
+      │ │( ) Bulgarian (Phonetic)                                     │ │
+      │ │( ) Canadian Bilingual                                       │ │
+      │ └─↓↓↓──────────────────────────────────────────────────── 12%─┘ │
+      ├─────────────────────────────────────────────────────────────────┤
+      │                      [Select]     [Cancel]                      │
+      └────────────────── Press arrows, TAB or ENTER ───────────────────┘
 ```
 
 #### Hostname
@@ -228,17 +225,17 @@ Press Enter to accept the default hostname, or replace it:
 
 This tutorial assumes that you are performing a fresh install, or a complete
 reinstall of your Morello system, with the intention of booting only CheriBSD.
-It also assumes that you will be using the UFS file system.
+It also assumes that you will be using the ZFS file system.
 If these assumpsions are not true, read the FreeBSD documentation for more
 information on partitioning disks before proceeding.
 
-Press Enter to select an automated UFS install:
+Press Enter to select an automated ZFS install:
 ```
               ┌─────────────────┤Partitioning├──────────────────┐
               │ How would you like to partition your disk?      │
               │ ┌─────────────────────────────────────────────┐ │
+              │ │Auto (ZFS) Guided Root-on-ZFS                │ │
               │ │Auto (UFS) Guided UFS Disk Setup             │ │
-              │ │Auto (ZFS) EXPERIMENTAL Guided Root-on-ZFS   │ │
               │ │Manual     Manual Disk Setup (experts)       │ │
               │ │Shell      Open a shell and partition by hand│ │
               │ └─────────────────────────────────────────────┘ │
@@ -247,89 +244,84 @@ Press Enter to select an automated UFS install:
               └─────────────────────────────────────────────────┘
 ```
 
-#### Partition (entire disk)
+Note that some advanced ZFS features are experimental and not well-tested on
+CHERI.
+Please see the release notes for caveats before deviating from the default
+configuration used in this guide.
 
-Select Entire Disk and press Enter:
+#### ZFS configuration (configure options)
+
+Press Enter to select Install (the next steps will prompt for any disks to
+use):
 
 ```
-                 ┌────────────────┤Partition├────────────────┐
-                 │ Would you like to use this entire disk    │
-                 │ (ada0) for FreeBSD or partition it to     │
-                 │ share it with other operating systems?    │
-                 │ Using the entire disk will erase any data │
-                 │ currently stored there.                   │
-                 ├───────────────────────────────────────────┤
-                 │      [Entire Disk]     [ Partition ]      │
-                 └───────────────────────────────────────────┘
+           ┌──────────────────┤ZFS Configuration├──────────────────┐
+           │ Configure Options:                                    │
+           │ ┌───────────────────────────────────────────────────┐ │
+           │ │ >>> Install         Proceed with Installation     │ │
+           │ │ T Pool Type/Disks:  stripe: 0 disks               │ │
+           │ │ - Rescan Devices    *                             │ │
+           │ │ - Disk Info         *                             │ │
+           │ │ N Pool Name         zroot                         │ │
+           │ │ 4 Force 4K Sectors? YES                           │ │
+           │ │ E Encrypt Disks?    NO                            │ │
+           │ │ P Partition Scheme  GPT (UEFI)                    │ │
+           │ │ S Swap Size         4g                            │ │
+           │ │ M Mirror Swap?      NO                            │ │
+           │ │ W Encrypt Swap?     NO                            │ │
+           │ │ O ZFS Pool Options  -O compress=lz4 -O atime=off  │ │
+           │ └───────────────────────────────────────────────────┘ │
+           ├───────────────────────────────────────────────────────┤
+           │                 [Select]     [Cancel]                 │
+           └──── Use alnum, arrows, punctuation, TAB or ENTER ─────┘
 ```
 
-#### Partition (entire disk - confirmation)
+#### ZFS configuration (virtual device type)
 
-Press Enter to confirm:
+Press Enter to select stripe:
 ```
-                 ┌────────────────┤Partition├────────────────┐
-                 │ Would you like to use this entire disk    │
-                 │ (ada┌────────┤Confirmation├─────────┐     │
-                 │ shar│ This will erase the disk. Are │     │
-                 │ Usin│ you sure you want to proceed? │  ta │
-                 │ curr├───────────────────────────────┤     │
-                 ├─────│     [ Yes  ]     [  No  ]     │  ───┤
-                 │     └───────────────────────────────┘     │
-                 └───────                                 ───┘
-```
-
-#### Partition Editor
-
-Review the proposed partition scheme, select Finish, and then press Enter to
-proceed:
-```
-            ┌─────────────────┤Partition Editor├──────────────────┐
-            │ Please review the disk setup. When complete, press  │
-            │ the Finish button.                                  │
-            │                                                     │
-            │                                                     │
-            │ ┌─────────────────────────────────────────────────┐ │
-            │ │ada0       224 GB    GPT                         │ │
-            │ │  ada0p1   260 MB    efi             /boot/efi   │ │
-            │ │  ada0p2   220 GB    freebsd-ufs     /           │ │
-            │ │  ada0p3   3.6 GB    freebsd-swap    none        │ │
-            │ │da0        29 GB     GPT                         │ │
-            │ │  da0p1    33 MB     efi                         │ │
-            │ │  da0p2    3.0 GB    freebsd-ufs                 │ │
-            │ │                                                 │ │
-            │ │                                                 │ │
-            │ │                                                 │ │
-            │ └─────────────────────────────────────────────────┘ │
-            ├─────────────────────────────────────────────────────┤
-            │[Create] [Delete] [Modify] [Revert] [ Auto ] [Finish]│
-            └─────────────────────────────────────────────────────┘
+                ┌─────────────┤ZFS Configuration├─────────────┐
+                │ Select Virtual Device type:                 │
+                │ ┌─────────────────────────────────────────┐ │
+                │ │ stripe Stripe - No Redundancy           │ │
+                │ │ mirror Mirror - n-Way Mirroring         │ │
+                │ │ raid10 RAID 1+0 - n x 2-Way Mirrors     │ │
+                │ │ raidz1 RAID-Z1 - Single Redundant RAID  │ │
+                │ │ raidz2 RAID-Z2 - Double Redundant RAID  │ │
+                │ │ raidz3 RAID-Z3 - Triple Redundant RAID  │ │
+                │ └─────────────────────────────────────────┘ │
+                ├─────────────────────────────────────────────┤
+                │            [  OK  ]     [Cancel]            │
+                └──────── Press arrows, TAB or ENTER ─────────┘
 ```
 
-#### Partition editor - confirmation
+#### ZFS configuration (disks)
 
-Select Commit and press Enter to continue with writing out a new partition
-table:
+Use the arrow keys and Space to select the disks to use:
 ```
-            ┌─────────────────┤Partition Editor├──────────────────┐
-            │ Please review the disk setup. When complete, press  │
-            │ the Finish button.                                  │
-            │                                                     │
-            │                                                     │
-            │ ┌─────────────────────────────────────────────────┐ │
-            │ │┌────────────────┤Confirmation├─────────────────┐│ │
-            │ ││ Your changes will now be written to disk. If  │  │
-            │ ││ you have chosen to overwrite existing data,   │  │
-            │ ││ it will be PERMANENTLY ERASED. Are you sure   │  │
-            │ ││ you want to commit your changes?              │  │
-            │ │├───────────────────────────────────────────────┤  │
-            │ ││[   Commit    ] [Revert & Exit] [    Back     ]│  │
-            │ │└───────────────────────────────────────────────┘  │
-            │ │                                                   │
-            │ │                                                 │ │
-            │ └─────────────────────────────────────────────────┘ │
-            ├─────────────────────────────────────────────────────┤
-            │[Create] [Delete] [Modify] [Revert] [ Auto ] [Finish]│
-            └─────────────────────────────────────────────────────┘
+            ┌─────────────────┤ZFS Configuration├────────────────┐
+            │ Please select one or more disks to create a zpool: │
+            │ ┌────────────────────────────────────────────────┐ │
+            │ │         [X] ada0 WDC WDS240G2G0A-00JH30        │ │
+            │ └────────────────────────────────────────────────┘ │
+            ├────────────────────────────────────────────────────┤
+            │                [  OK  ]     [ Back ]               │
+            └────────── Use arrows, SPACE, TAB or ENTER ─────────┘
+```
+
+#### ZFS configuration (confirmation)
+
+Select YES and press Enter to confirm:
+```
+              ┌───────────────┤ZFS Configuration├──────────────┐
+              │ Last Chance! Are you sure you want to destroy  │
+              │ the current contents of the following disks:   │
+              │                                                │
+              │  ada0                                          │
+              │                                                │
+              ├────────────────────────────────────────────────┤
+              │              [ YES  ]     [  NO  ]             │
+              └────────── Press arrows, TAB or ENTER ──────────┘
 ```
 
 #### The installation proceeds
@@ -340,28 +332,27 @@ Unless something goes wrong, no user interaction is required.
 Typical output from the installation process will look like this:
 
 ```
-┌───────────────────────────┤Checksum Verification├──────────────────────────┐
-│ base.txz                                                   [ In Progress ] │
-│ kernel.txz                                                 [   Pending   ] │
-│ base-dbg.txz                                               [   Pending   ] │
-│ kernel-dbg.txz                                             [   Pending   ] │
-│ kernel.GENERIC-MORELLO-NOCAPREVOKE-NODEBUG-dbg.txz         [   Pending   ] │
-│ kernel.GENERIC-MORELLO-NOCAPREVOKE-NODEBUG.txz             [   Pending   ] │
-│ kernel.GENERIC-MORELLO-NOCAPREVOKE-dbg.txz                 [   Pending   ] │
-│ kernel.GENERIC-MORELLO-NOCAPREVOKE.txz                     [   Pending   ] │
-│ kernel.GENERIC-MORELLO-NODEBUG-dbg.txz                     [   Pending   ] │
-│ kernel.GENERIC-MORELLO-NODEBUG.txz                         [   Pending   ] │
-│ kernel.GENERIC-MORELLO-PURECAP-BENCHMARK-NOCAPREVOKE-NO... [   Pending   ] │
-│ kernel.GENERIC-MORELLO-PURECAP-BENCHMARK-NOCAPREVOKE-NO... [   Pending   ] │
-│ kernel.GENERIC-MORELLO-PURECAP-BENCHMARK-NOCAPREVOKE-db... [   Pending   ] │
-│ ...                                                                        │
-│                                                                            │
-│ Verifying checksums of selected distributions.                             │
-│                                                                            │
-│  ┌─Overall Progress─────────────────────────────────────────────────────┐  │
-│  │                                   0%                                 │  │
-│  └──────────────────────────────────────────────────────────────────────┘  │
-└────────────────────────────────────────────────────────────────────────────┘
+ ┌──────────────────────────┤Checksum Verification├─────────────────────────┐
+ │ base.txz                                                 [ In Progress ] │
+ │ kernel.txz                                               [   Pending   ] │
+ │ base-dbg.txz                                             [   Pending   ] │
+ │ kernel-dbg.txz                                           [   Pending   ] │
+ │ kernel.GENERIC-MORELLO-NODEBUG-dbg.txz                   [   Pending   ] │
+ │ kernel.GENERIC-MORELLO-NODEBUG.txz                       [   Pending   ] │
+ │ kernel.GENERIC-MORELLO-PURECAP-BENCHMARK-NODEBUG-dbg.txz [   Pending   ] │
+ │ kernel.GENERIC-MORELLO-PURECAP-BENCHMARK-NODEBUG.txz     [   Pending   ] │
+ │ kernel.GENERIC-MORELLO-PURECAP-BENCHMARK-dbg.txz         [   Pending   ] │
+ │ kernel.GENERIC-MORELLO-PURECAP-BENCHMARK.txz             [   Pending   ] │
+ │ kernel.GENERIC-MORELLO-PURECAP-NODEBUG-dbg.txz           [   Pending   ] │
+ │ kernel.GENERIC-MORELLO-PURECAP-NODEBUG.txz               [   Pending   ] │
+ │ ...                                                                      │
+ │                                                                          │
+ │ Verifying checksums of selected distributions.                           │
+ │                                                                          │
+ │  ┌─Overall Progress───────────────────────────────────────────────────┐  │
+ │  │                                  0%                                │  │
+ │  └────────────────────────────────────────────────────────────────────┘  │
+ └──────────────────────────────────────────────────────────────────────────┘
 ```
 
 #### Updating the EFI configuration table
@@ -383,119 +374,39 @@ Press Enter to proceed:
 #### Setting a root password
 
 Enter a new root password and press Enter.
-Then confirm it by typing the same password again and pressing Enter.
+Then confirm it by typing the same password again and pressing Enter:
 
 ```
 Please select a password for the system management account (root):
 Typed characters will not be visible.
 Changing local password for root
 New Password:
+Retype New Password:
 ```
 
 #### Network configuration
 
-If desired, configure Ethernet networking by pressing Enter.
+If desired, configure Ethernet networking by pressing Enter to select Auto:
 
 ```
       ┌─────────────────────┤Network Configuration├─────────────────────┐
-      │ Please select a network interface to configure:                 │
+      │ Please select a network interface and configuration mode:       │
       │ ┌─────────────────────────────────────────────────────────────┐ │
       │ │re0 RealTek 8168/8111 B/C/CP/D/DP/E/F/G PCIe Gigabit Ethernet│ │
       │ └─────────────────────────────────────────────────────────────┘ │
       ├─────────────────────────────────────────────────────────────────┤
-      │                      [  OK  ]     [Cancel]                      │
+      │               [ Auto ]     [Manual]     [Cancel]                │
       └─────────────────────────────────────────────────────────────────┘
 ```
 
-#### Network configuration - enabling IPv4
-
-If desired, enable IPv4 on the Ethernet interface by selecting Yes and
-pressing Enter:
-```
-                        ┌───┤Network Configuration├───┐
-                        │ Would you like to configure │
-                        │ IPv4 for this interface?    │
-                        ├─────────────────────────────┤
-                        │    [ Yes  ]    [  No  ]     │
-                        └─────────────────────────────┘
-```
-
-#### Network configuration - DHCP for IPv4
-
-If you will be using DHCP, select Yes and press Enter.
-Otherwise select No and press Enter to perform a manual IPv4 configuration.
-
-```
-                       ┌────┤Network Configuration├───┐
-                       │ Would you like to use DHCP   │
-                       │ to configure this interface? │
-                       ├──────────────────────────────┤
-                       │     [ Yes  ]    [  No  ]     │
-                       └──────────────────────────────┘
-```
-
-#### Network configuration - enabling IPv6
-
-If desired, enable IPv6 on the Ethernet interface by selecting Yes and
-pressing Enter:
-```
-                        ┌───┤Network Configuration├───┐
-                        │ Would you like to configure │
-                        │ IPv6 for this interface?    │
-                        ├─────────────────────────────┤
-                        │    [ Yes  ]    [  No  ]     │
-                        └─────────────────────────────┘
-```
-
-#### Network configuration - SLAAC for IPv6
-
-Press Enter to use stateless address autoconfiguration for IPv6:
-```
-                      ┌─────┤Network Configuration├─────┐
-                      │ Would you like to try stateless │
-                      │ address autoconfiguration       │
-                      │ (SLAAC)?                        │
-                      ├─────────────────────────────────┤
-                      │      [ Yes  ]     [  No  ]      │
-                      └─────────────────────────────────┘
-```
-
-#### Network configuration - resolver configuration
-
-Enter DNS resolution configuration information, or press Enter to confirm
-autoconfigured DNS configuration:
-```
-    ┌───────────────────────┤Network Configuration├───────────────────────┐
-    │ Resolver Configuration                                              │
-    │ ┌─────────────────────────────────────────────────────────────────┐ │
-    │ │Search         localdomain                                       │ │
-    │ │IPv6 DNS #1                                                      │ │
-    │ │IPv6 DNS #2                                                      │ │
-    │ │IPv4 DNS #1    192.168.1.1                                       │ │
-    │ │IPv4 DNS #2                                                      │ │
-    │ └─────────────────────────────────────────────────────────────────┘ │
-    ├─────────────────────────────────────────────────────────────────────┤
-    │                        [  OK  ]     [Cancel]                        │
-    └─────────────────────────────────────────────────────────────────────┘
-```
-
-#### Local or UTC clock
-
-Press Enter to select a system clock on UTC:
-```
-   ┌───────────┤Select local or UTC (Greenwich Mean Time) clock├───────────┐
-   │ Is this machine's CMOS clock set to UTC?  If it is set to local time, │
-   │ or you don't know, please choose NO here!                             │
-   │                                                                       │
-   ├───────────────────────────────────────────────────────────────────────┤
-   │                          [ Yes  ]   [  No  ]                          │
-   └───────────────────────────────────────────────────────────────────────┘
-```
+If this fails (e.g. your network requires static configuration), you may be
+asked to provide additional information, or you may need to retry selecting
+Manual.
 
 #### Timezone selection
 
 Press Enter to select UTC as your timezone; otherwise, select your continent
-and press Enter.
+and press Enter:
 ```
                       ┌──────┤Time Zone Selector├───────┐
                       │ Select a region                 │
@@ -519,35 +430,35 @@ and press Enter.
 
 If you have not selected UTC, select your country and press Enter:
 ```
-        ┌────────────────────┤Countries in Europe├────────────────────┐
-        │ Select a country or region                                  │
-        │ ┌─^^^─────────────────────────────────────────────────────┐ │
-        │ │ 35 Poland                                               │ │
-        │ │ 36 Portugal                                             │ │
-        │ │ 37 Romania                                              │ │
-        │ │ 38 Russian Federation                                   │ │
-        │ │ 39 San Marino                                           │ │
-        │ │ 40 Serbia                                               │ │
-        │ │ 41 Slovakia                                             │ │
-        │ │ 42 Slovenia                                             │ │
-        │ │ 43 Spain                                                │ │
-        │ │ 44 Svalbard and Jan Mayen                               │ │
-        │ │ 45 Sweden                                               │ │
-        │ │ 46 Switzerland                                          │ │
-        │ │ 47 Turkey                                               │ │
-        │ │ 48 Ukraine                                              │ │
-        │ │ 49 United Kingdom of Great Britain and Northern Ireland │ │
-        │ │ 50 Åland Islands                                        │ │
-        │ └────────────────────────────────────────────────100%─────┘ │
-        ├─────────────────────────────────────────────────────────────┤
-        │                     [  OK  ]   [Cancel]                     │
-        └─────────────────────────────────────────────────────────────┘
+         ┌───────────────────┤Countries in Europe├───────────────────┐
+         │ Select a country or region                                │
+         │ ┌───────────────────────────────────────────────────────┐ │
+         │ │1  Albania                                             │ │
+         │ │2  Andorra                                             │ │
+         │ │3  Austria                                             │ │
+         │ │4  Belarus                                             │ │
+         │ │5  Belgium                                             │ │
+         │ │6  Bosnia and Herzegovina                              │ │
+         │ │7  Bulgaria                                            │ │
+         │ │8  Croatia                                             │ │
+         │ │9  Cyprus                                              │ │
+         │ │10 Czech Republic                                      │ │
+         │ │11 Denmark                                             │ │
+         │ │12 Estonia                                             │ │
+         │ │13 Finland                                             │ │
+         │ │14 France                                              │ │
+         │ │15 Germany                                             │ │
+         │ │16 Gibraltar                                           │ │
+         │ └─↓↓↓────────────────────────────────────────────── 32%─┘ │
+         ├───────────────────────────────────────────────────────────┤
+         │                   [  OK  ]     [Cancel]                   │
+         └───────────────────────────────────────────────────────────┘
 ```
 
 Confirm your choice by selecting Yes and pressing Enter:
 ```
    ┌────────────────────────────┤Confirmation├────────────────────────────┐
-   │ Does the abbreviation `UTC' look reasonable?                         │
+   │ Does the timezone abbreviation `UTC' look reasonable?                │
    ├──────────────────────────────────────────────────────────────────────┤
    │                         [ Yes  ]     [  No  ]                        │
    └──────────────────────────────────────────────────────────────────────┘
@@ -561,15 +472,15 @@ to use network time synchronization:
                    ┌─────────────┤Time & Date├────────────┐
                    │  Month            Year               │
                    │  ┌───────────────┐┌───────────────┐  │
-                   │  │           July││           2024│  │
+                   │  │           July││           2026│  │
                    │  └───────────────┘└───────────────┘  │
                    │  ┌────────────────────────────────┐  │
                    │  │    Sun Mon Tue Wed Thu Fri Sat │  │
-                   │  │         1   2   3   4   5   6  │  │
-                   │  │     7   8   9  10  11  12  13  │  │
-                   │  │    14  15  16  17  18  19  20  │  │
-                   │  │    21  22  23  24  25  26  27  │  │
-                   │  │    28  29  30  31              │  │
+                   │  │                 1   2   3   4  │  │
+                   │  │     5   6   7   8   9  10  11  │  │
+                   │  │    12  13  14  15  16  17  18  │  │
+                   │  │    19  20  21  22  23  24  25  │  │
+                   │  │    26  27  28  29  30  31      │  │
                    │  │                                │  │
                    │  └────────────────────────────────┘  │
                    ├──────────────────────────────────────┤
@@ -581,7 +492,7 @@ And, likewise, the time:
 ```
                    ┌─────────────┤Time & Date├────────────┐
                    │            ┌──┐ ┌──┐ ┌──┐            │
-                   │            │11│:│23│:│20│            │
+                   │            │11│:│59│:│41│            │
                    │            └──┘ └──┘ └──┘            │
                    ├──────────────────────────────────────┤
                    │       [Set Time]     [  Skip  ]      │
@@ -612,12 +523,27 @@ selecting them and hitting Space:
 
 Then press Enter to continue.
 
+#### Firmware
+
+The installer will detect no firmware is needed for the system and
+automatically proceed to the next step after 5 seconds:
+```
+                   ┌────┤FreeBSD Firmware Installation├────┐
+                   │ No firmware to install, continuing... │
+                   │  ┌─────────────────────────────────┐  │
+                   │  │                5                │  │
+                   │  └─────────────────────────────────┘  │
+                   ├───────────────────────────────────────┤
+                   │               [  OK  ]                │
+                   └──────── Press OK to continue ─────────┘
+```
+
 #### Add user accounts
 
 If you plan to install the desktop environment in the next step, it is
 useful to create user accounts now.
 If desired, select Yes and press Enter to add non-root accounts.
-Otherwise, select No and press Enter
+Otherwise, select No and press Enter:
 
 ```
                        ┌──────┤Add User Accounts├─────┐
@@ -668,15 +594,15 @@ CHERI-enabled virtual machines, press Enter:
 #### Final configuration
 
 If there are further configuration settings to change, use the up/down arrow
-keys to highlight an appropriate option from the menu, then use the left arrow
-key to select the Select button and press Enter.
-Otherwise, press Enter to complete the installation:
+keys to highlight an appropriate option from the menu and press Enter.
+Otherwise, with Finish highlighted, press Enter to complete the installation:
 ```
 ┌────────────────────────────┤Final Configuration├───────────────────────────┐
 │ Setup of your FreeBSD system is nearly complete. You can now modify your   │
 │ configuration choices. After this screen, you will have an opportunity to  │
 │ make more complex changes using a shell.                                   │
 │ ┌────────────────────────────────────────────────────────────────────────┐ │
+│ │Finish           Apply configuration and exit installer                 │ │
 │ │Add User         Add a user to the system                               │ │
 │ │Root Password    Change root password                                   │ │
 │ │Hostname         Set system hostname                                    │ │
@@ -684,12 +610,12 @@ Otherwise, press Enter to complete the installation:
 │ │Services         Set daemons to run on startup                          │ │
 │ │System Hardening Set security options                                   │ │
 │ │Time Zone        Set system timezone                                    │ │
+│ │Firmware         Install Firmware (requires network)                    │ │
 │ │Handbook         Install FreeBSD Handbook (requires network)            │ │
 │ │CHERI Desktop    Install the CHERI desktop environment (requires network│ │
-│ │CHERI VM Support Install CHERI virtual machine support (requires network│ │
-│ └────────────────────────────────────────────────────────────────────────┘ │
+│ └─↓↓↓─────────────────────────────────────────────────────────────── 91%─┘ │
 ├────────────────────────────────────────────────────────────────────────────┤
-│                            [Select]     [Finish]                           │
+│                                  [Select]                                  │
 └────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -739,17 +665,16 @@ installation process:
 ...
 Performing sanity check on sshd configuration.
 Starting sshd.
-Starting cron.
 Starting background file system checks in 60 seconds.
-Starting sddm.
 
-Sat Jul 20 00:12:09 UTC
+Wed Jul 22 12:03:31 UTC 2026
+
 CheriBSD/arm64 (cheribsd) (ttyu0)
 
 login: root
 Password:
-Jul 20 00:12:13 cheribsd login[968]: ROOT LOGIN (root) ON ttyu0
-FreeBSD 15.0-CURRENT (GENERIC-MORELLO-PURECAP) #0 releng/24.05-b2ad856aac65: Fri Jul 19 21:17:24 UTC 2024
+Jul 22 12:03:41 cheribsd login[2005]: ROOT LOGIN (root) ON ttyu0
+FreeBSD 15.0-CURRENT (GENERIC-MORELLO-PURECAP) #0 releng/26.07-88f39900c329: Tue Jul 21 10:20:31 UTC 2026
 
 Welcome to CheriBSD!
 

--- a/src/morello-issues/README.md
+++ b/src/morello-issues/README.md
@@ -45,6 +45,18 @@ CheriBSD on Morello:
   Currently, there is no workaround for this issue and it is likely to occur
   with the HDMI transmitter issue described above.
 
+- The firmware can report messages that appear to be errors when booting a
+  kernel with a large number of compartments (e.g., security/kernel-c18n-cpm
+  from CheriBSD ports). For example:
+  ```
+  ConvertPages: Incompatible memory types, the pages to allocate have been allocated
+  (...)
+  ConvertPages: range E0000000 - E0843FFF covers multiple entries
+  ```
+  These messages are harmless and expected. The Morello firmware uses a debug
+  build of EDK2 that prints additional diagnostic messages, in this case to
+  explain why it could not grow the boot loader's memory allocation in-place.
+
 ## Issues with older firmware
 
 The following issues affected users of older firmware revisions:

--- a/src/nonfeatures/README.md
+++ b/src/nonfeatures/README.md
@@ -2,11 +2,14 @@
 
 Certain FreeBSD features are currently unavailable in CheriBSD, including:
 
-- DTrace
+- DTrace on hybrid kernels or with the kinst provider
+- Linux binary compatibility ("Linuxulator")
 
 Many other kernel features are not yet well validated, including:
 
 - Most optional modules, such as various firewall systems
+- Some advanced ZFS features; see the release notes for caveats before
+  deviating from the default configuration used in this guide.
 
 ## Reporting bugs
 Bug reports relating to these under-validated subsystems would be appreciated,

--- a/src/updating/README.md
+++ b/src/updating/README.md
@@ -1,0 +1,132 @@
+# Updating an existing system
+
+The
+[cheribsd-update](https://man.cheribsd.org/cgi-bin/man.cgi/release-26.07/cheribsd-update.8)
+tool, available as an optional installable package, can be used to update an
+existing CheriBSD 25.03 installation to 26.07.
+Due to CheriBSD's evolving ABI, backwards compatibility is only ensured for
+consecutive releases, and so intermediate releases cannot be skipped when
+upgrading an existing CheriBSD installation.
+
+***Although every effort has been made to handle errors and corner cases, bugs
+may exist, and so to avoid possible data loss you should back up any important
+system contents before following these steps.***
+
+In order to use cheribsd-update, you must first install it using:
+
+```
+pkg64c install cheribsd-update
+```
+
+Once installed, you can start the update process using:
+
+```
+cheribsd-update update 25.03 26.07
+```
+
+This step will download quite a few large files to perform the update, and so
+may take some time.
+Once downloaded, it will inspect the running system, and outline the system
+components that will be updated, added, and removed.
+For an update from 25.03 to 26.07 this should look as follows:
+
+```
+--------------------------------------------------------------
+>>> Confirm update
+--------------------------------------------------------------
+The following distribution sets will be updated:
+    base
+    base-dbg
+    kernel
+    kernel-dbg
+    kernel.GENERIC-MORELLO
+    kernel.GENERIC-MORELLO-NODEBUG
+    kernel.GENERIC-MORELLO-NODEBUG-dbg
+    kernel.GENERIC-MORELLO-PURECAP-BENCHMARK
+    kernel.GENERIC-MORELLO-PURECAP-BENCHMARK-NODEBUG
+    kernel.GENERIC-MORELLO-PURECAP-BENCHMARK-NODEBUG-dbg
+    kernel.GENERIC-MORELLO-PURECAP-BENCHMARK-dbg
+    kernel.GENERIC-MORELLO-PURECAP-NODEBUG
+    kernel.GENERIC-MORELLO-PURECAP-NODEBUG-dbg
+    kernel.GENERIC-MORELLO-dbg
+    lib32
+    lib32-dbg
+    lib64
+    lib64-dbg
+    lib64cb
+    lib64cb-dbg
+    tests
+
+The following distribution sets will be removed:
+    kernel.GENERIC-MORELLO-NOCAPREVOKE
+    kernel.GENERIC-MORELLO-NOCAPREVOKE-NODEBUG
+    kernel.GENERIC-MORELLO-NOCAPREVOKE-NODEBUG-dbg
+    kernel.GENERIC-MORELLO-NOCAPREVOKE-dbg
+    kernel.GENERIC-MORELLO-PURECAP-BENCHMARK-NOCAPREVOKE
+    kernel.GENERIC-MORELLO-PURECAP-BENCHMARK-NOCAPREVOKE-NODEBUG
+    kernel.GENERIC-MORELLO-PURECAP-BENCHMARK-NOCAPREVOKE-NODEBUG-dbg
+    kernel.GENERIC-MORELLO-PURECAP-BENCHMARK-NOCAPREVOKE-dbg
+    kernel.GENERIC-MORELLO-PURECAP-NOCAPREVOKE
+    kernel.GENERIC-MORELLO-PURECAP-NOCAPREVOKE-NODEBUG
+    kernel.GENERIC-MORELLO-PURECAP-NOCAPREVOKE-NODEBUG-dbg
+    kernel.GENERIC-MORELLO-PURECAP-NOCAPREVOKE-dbg
+
+Proceed? [Y/n] 
+```
+
+If this looks as expected, confirm at the prompt with the Enter key.
+This will update the kernel, at which point you will be asked to reboot and
+resume the update:
+
+```
+--------------------------------------------------------------
+>>> Reboot required; please reboot then run:
+>>>     cheribsd-update [-D destdir] resume
+>>> to continue updating
+--------------------------------------------------------------
+```
+
+Once rebooted, log in as usual.
+As part of updating the rest of the system, this next step will remove old
+versions of libraries, some of which may be required by tools such as sudo.
+If you are not able to log in as the root user directly but instead use sudo,
+it is recommended that you use a root shell via <code>sudo -i</code>, as you
+may not be able to use sudo immediately after the update.
+
+With a suitable shell, resume and finish the update with:
+
+```
+cheribsd-update resume
+```
+
+If there are conflicts when updating configuration files you will be asked to
+resolve them in turn:
+
+```
+--------------------------------------------------------------
+>>> Running etcupdate resolve
+--------------------------------------------------------------
+Resolving conflict in '/etc/devd.conf':
+Select: (p) postpone, (df) diff-full, (e) edit,
+        (h) help for more options: 
+```
+
+Once finished, cheribsd-update should give the following message:
+
+```
+--------------------------------------------------------------
+>>> Update finished; please upgrade any installed packages
+--------------------------------------------------------------
+```
+
+You should now update your packages with:
+
+```
+pkg64c bootstrap -f
+pkg64c upgrade
+```
+(NB: bootstrap -f reinstalls the package manager, in case it requires removed
+library versions)
+
+Repeat this bootstrap and upgrade process for any other package ABIs installed.
+Restart once more to ensure all system processes are running the new version.


### PR DESCRIPTION
Includes a new section on updating using cheribsd-update, since is the
first release where we're officially supporting that for outside users,
after testing it internally for the past year or so.
